### PR TITLE
Fix for crash when application exits in SGXLKL software mode

### DIFF
--- a/enclave/core/sgx/calls.c
+++ b/enclave/core/sgx/calls.c
@@ -434,7 +434,7 @@ static void _handle_ecall(
 done:
 
     /* Free shared memory arena before we clear TLS */
-    if (td->depth == 1)
+    if (td->depth == 1 && !td->simulate)
     {
         oe_teardown_arena();
     }

--- a/enclave/core/sgx/linux/threadlocal.c
+++ b/enclave/core/sgx/linux/threadlocal.c
@@ -362,6 +362,9 @@ void __cxa_thread_atexit(void (*destructor)(void*), void* object)
  */
 oe_result_t oe_thread_local_cleanup(td_t* td)
 {
+    /* OE thread local clean up not required in SW mode for SGXLKL */
+    if (td->simulate) return OE_OK;
+
     /* Call tls atexit functions in reverse order*/
     if (_tls_atexit_functions)
     {


### PR DESCRIPTION
**HW Mode**
[   SGX-LKL  ] Calling app main: /usr/bin/java
OpenJDK 64-Bit Server VM warning: Can't detect primordial thread stack location - find_vma failed
[   SIGNAL   ] sgxlkl_enclave_signal_handler:: code=3 address=0x7f153bd4f1ca opcode=0xa20f
[   SIGNAL   ] sgxlkl_enclave_signal_handler:: code=3 address=0x7f153bd4f1e5 opcode=0xa20f
[   SIGNAL   ] sgxlkl_enclave_signal_handler:: code=3 address=0x7f153bd4f20f opcode=0xa20f
[   SIGNAL   ] sgxlkl_enclave_signal_handler:: code=5 address=0x7f153bd4f2b4 opcode=0x68b
[   SIGNAL   ] sgxlkl_enclave_signal_handler:: code=3 address=0x7f153bd4f2ec opcode=0xa20f
[   SIGNAL   ] sgxlkl_enclave_signal_handler:: code=3 address=0x7f153bd4f317 opcode=0xa20f
[   SIGNAL   ] sgxlkl_enclave_signal_handler:: code=3 address=0x7f153bd4f330 opcode=0xa20f
[   SIGNAL   ] sgxlkl_enclave_signal_handler:: code=3 address=0x7f153bd4f349 opcode=0xa20f
[   SIGNAL   ] sgxlkl_enclave_signal_handler:: code=3 address=0x7f153bd4f362 opcode=0xa20f
Hello SGX world from Java!
[    0.000000] EXT4-fs (vda): re-mounted. Opts: (null)
[    0.000000] reboot: Restarting system
[   SGX-LKL  ] sgxlkl_ethread_init done. ethread_id=7 result=0 (OE_OK)
[   SGX-LKL  ] sgxlkl_ethread_init done. ethread_id=3 result=0 (OE_OK)
[   SGX-LKL  ] sgxlkl_ethread_init done. ethread_id=5 result=0 (OE_OK)
[   SGX-LKL  ] sgxlkl_ethread_init done. ethread_id=2 result=0 (OE_OK)
[   SGX-LKL  ] sgxlkl_enclave_init done. ethread_id=0 result=0 (OE_OK)
[   SGX-LKL  ] sgxlkl_ethread_init done. ethread_id=1 result=0 (OE_OK)
[   SGX-LKL  ] sgxlkl_ethread_init done. ethread_id=6 result=0 (OE_OK)
[   SGX-LKL  ] oe_terminate_enclave... done
[   SGX-LKL  ] SGX-LKL-OE exit
johnson@SGX-LKL-TAB-Demo:~/fork/sgx-lkl-oe/apps/languages/java$

**SW Mode**
OpenJDK 64-Bit Server VM warning: Can't detect primordial thread stack location - find_vma failed
[   SIGNAL   ] sgxlkl_enclave_signal_handler:: code=5 address=0x0 opcode=0x68b
Hello SGX world from Java!
[    0.000000] EXT4-fs (vda): re-mounted. Opts: (null)
[    0.000000] reboot: Restarting system
[   SGX-LKL  ] sgxlkl_ethread_init done. ethread_id=7 result=0 (OE_OK)
[   SGX-LKL  ] sgxlkl_enclave_init done. ethread_id=0 result=0 (OE_OK)
[   SGX-LKL  ] sgxlkl_ethread_init done. ethread_id=1 result=0 (OE_OK)
[   SGX-LKL  ] sgxlkl_ethread_init done. ethread_id=5 result=0 (OE_OK)
[   SGX-LKL  ] sgxlkl_ethread_init done. ethread_id=3 result=0 (OE_OK)
[   SGX-LKL  ] sgxlkl_ethread_init done. ethread_id=2 result=0 (OE_OK)
[   SGX-LKL  ] sgxlkl_ethread_init done. ethread_id=6 result=0 (OE_OK)
[   SGX-LKL  ] oe_terminate_enclave... done
[   SGX-LKL  ] SGX-LKL-OE exit

