### PR TITLE
Fix cpuid test hang

### DIFF
--- a/enclave/core/sgx/linux/threadlocal.c
+++ b/enclave/core/sgx/linux/threadlocal.c
@@ -363,7 +363,8 @@ void __cxa_thread_atexit(void (*destructor)(void*), void* object)
 oe_result_t oe_thread_local_cleanup(td_t* td)
 {
     /* OE thread local clean up not required in SW mode for SGXLKL */
-    if (td->simulate) return OE_OK;
+    if (td->simulate)
+        return OE_OK;
 
     /* Call tls atexit functions in reverse order*/
     if (_tls_atexit_functions)

--- a/tests/cpuid/CMakeLists.txt
+++ b/tests/cpuid/CMakeLists.txt
@@ -8,3 +8,4 @@ if (BUILD_ENCLAVES)
 endif()
 
 add_enclave_test(tests/cpuid cpuid_host cpuid_enc)
+set_tests_properties(tests/cpuid PROPERTIES SKIP_RETURN_CODE 2)

--- a/tests/cpuid/enc/enc.c
+++ b/tests/cpuid/enc/enc.c
@@ -35,10 +35,12 @@ static uint64_t _exception_handler(oe_exception_record_t* exception)
     return OE_EXCEPTION_CONTINUE_SEARCH;
 }
 
-extern void (*oe_continue_execution_hook)(oe_context_t* context);
+extern void (*oe_continue_execution_hook)(oe_exception_record_t* record);
 
-static void _continue_execution_hook(oe_context_t* context)
+static void _continue_execution_hook(oe_exception_record_t* record)
 {
+    oe_context_t* context = record->context;
+
     if (*((uint16_t*)context->rip) == OE_CPUID_OPCODE)
     {
         uint32_t rax;

--- a/tests/cpuid/host/host.c
+++ b/tests/cpuid/host/host.c
@@ -12,6 +12,8 @@
 #include "../../../host/strings.h"
 #include "cpuid_u.h"
 
+#define SKIP_RETURN_CODE 2
+
 void cpuid_ocall(
     uint32_t leaf,
     uint32_t subleaf,
@@ -40,7 +42,12 @@ int main(int argc, const char* argv[])
     oe_result_t result;
     oe_enclave_t* enclave = NULL;
     oe_enclave_type_t type = OE_ENCLAVE_TYPE_SGX;
-    const uint32_t flags = OE_ENCLAVE_FLAG_DEBUG;
+    const uint32_t flags = oe_get_create_flags();
+
+    // In simulation mode cpuid instruction will just be successfully executed
+    // on the host and the exception handler will not be called.
+    if ((flags & OE_ENCLAVE_FLAG_SIMULATE) != 0)
+        return SKIP_RETURN_CODE;
 
     if (argc != 2)
     {


### PR DESCRIPTION
A bug in the cpuid test exception handler causes `rip` to be set to a garbage value which then leads the test hanging.