### PR TITLE
Update SGX w FLC driver to install on Ubuntu Bionic

### DIFF
--- a/scripts/ansible/roles/linux/intel/vars/bionic.yml
+++ b/scripts/ansible/roles/linux/intel/vars/bionic.yml
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 ---
-intel_sgx_w_flc_driver_url: "https://download.01.org/intel-sgx/dcap-1.2/linux/dcap_installers/ubuntuServer18.04/sgx_linux_x64_driver_1.12_c110012.bin"
+intel_sgx_w_flc_driver_url: "https://download.01.org/intel-sgx/sgx-dcap/1.4/linux/distro/ubuntuServer18.04/sgx_linux_x64_driver_1.21.bin"
 intel_sgx1_driver_url: "https://download.01.org/intel-sgx/linux-2.6/ubuntu18.04-server/sgx_linux_x64_driver_2.5.0_2605efa.bin"
 intel_sgx_package_dependencies:
   - "libprotobuf10"


### PR DESCRIPTION
The previous version to download and install no longer exists. The was causing an attempted build from
source that in turn would fail on Bionic.